### PR TITLE
Fix: avoid writing docblock for enums that dont use LaravelEnumHelper

### DIFF
--- a/tests/Feature/EnumAnnotateCommandTest.php
+++ b/tests/Feature/EnumAnnotateCommandTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Datomatic\LaravelEnumHelper\Tests\Support\Enums\DoesntUseEnumHelperTrait;
+
 beforeEach(function () {
     if (! file_exists(app_path('Enums'))) {
         mkdir(app_path('Enums'), 0755, true);
@@ -42,7 +44,6 @@ it('can be success single file', function () {
     $this->assertEquals(1, substr_count($contents, '@method static string discarded()'));
     $this->assertEquals(1, substr_count($contents, '@method static string noResponse()'));
 });
-
 
 it('can be success single file int backed enum', function () {
     $this->artisan("enum:annotate --folder={$this->withoutDocBlockEnumsFolder} Datomatic\\\\LaravelEnumHelper\\\\Tests\\\\Support\\\\WithoutDocBlockEnums\\\\StatusIntWithoutDocBlock")
@@ -94,6 +95,13 @@ it('can be success whole folder', function () {
     $this->assertEquals(1, substr_count($contents, '@method static string accepted()'));
     $this->assertEquals(1, substr_count($contents, '@method static string discarded()'));
     $this->assertEquals(1, substr_count($contents, '@method static string noResponse()'));
+});
+
+it('doesnt annotate enums that dont use LaravelEnumTrait', function () {
+    $this->artisan('enum:annotate Datomatic\\\\LaravelEnumHelper\\\\Tests\\\\Support\\\\Enums\\\\DoesntUseEnumHelperTrait')
+        ->assertSuccessful();
+    $e = new ReflectionEnum(DoesntUseEnumHelperTrait::class);
+    $this->assertEquals(false, $e->getDocComment());
 });
 
 it('can be failed with class', function () {

--- a/tests/Feature/LaravelEnumHelperTest.php
+++ b/tests/Feature/LaravelEnumHelperTest.php
@@ -139,13 +139,13 @@ it('can return an array of translations with method name both singular and plura
     'translations with lang and cases param' => [Status::class, [Status::ACCEPTED, Status::NO_RESPONSE], 'it', ['ITA news ACCEPTED', 'ITA news NO_RESPONSE']],
 ]);
 
-//it('can\'t return an array of method results with method name both singular and plural', function ($enumClass, $cases, $lang) {
+// it('can\'t return an array of method results with method name both singular and plural', function ($enumClass, $cases, $lang) {
 //    expect(fn() => $enumClass::news($cases, $lang))->toRuntimeError();
-//})->with([
+// })->with([
 //    'enum with method' => [StatusString::class, null, null],
 //    'enum with method with cases param' => [StatusString::class, [StatusString::DISCARDED, StatusString::ACCEPTED], null],
 //    'enum with method with lang and cases param' => [StatusString::class, [StatusString::NO_RESPONSE, StatusString::ACCEPTED], 'it'],
-//]);
+// ]);
 
 it('can return an array of translations with magic method', function ($enumClass, $cases, $lang, $result) {
     expect($enumClass::excerpts($cases, $lang))->toBe($result);

--- a/tests/Support/Enums/DoesntUseEnumHelperTrait.php
+++ b/tests/Support/Enums/DoesntUseEnumHelperTrait.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Datomatic\LaravelEnumHelper\Tests\Support\Enums;
+
+enum DoesntUseEnumHelperTrait
+{
+    case FOO;
+    case BAR;
+}

--- a/tests/stubs/DoesntUseEnumHelperTrait.stub
+++ b/tests/stubs/DoesntUseEnumHelperTrait.stub
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Datomatic\LaravelEnumHelper\Tests\Support\Enums;
+
+enum DoesntUseEnumHelperTrait {
+    case FOO;
+    case BAR;
+}


### PR DESCRIPTION
as in the pr title + typofix in EnumAnnotateCommand@annotateClass (undefined variable)